### PR TITLE
Remove abusive requirement limitation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "ext-rdkafka": "^0.9.1"
+        "ext-rdkafka": ">=0.9 ~2.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
Since API doesn't change from version 0.9 to 2.0, we should allow this stubs working with version 2.0 of ext-kafka.