### PR TITLE
Remove abusive requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "ext-rdkafka": ">=0.9 ~2.0.0"
+        "ext-rdkafka": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "ext-rdkafka": "^0.9.1"
+        "ext-rdkafka": ">=0.9 ~2.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
Since API doesn't change with version 2.0, we should allow the use of this stubs on all versions of extension.