### PR TITLE
Make payload nullable for compacted topics / tombstones

### DIFF
--- a/stubs/RdKafka/Message.php
+++ b/stubs/RdKafka/Message.php
@@ -20,7 +20,7 @@ class Message
     public $partition;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $payload;
 


### PR DESCRIPTION
https://kafka.apache.org/documentation/#design_compactionbasics
Compacted Topics and Tombstones have a key set, but payload is null